### PR TITLE
Fixbug that docstring.nvim does not work on methods not in top-level

### DIFF
--- a/rplugin/python3/docstring.py
+++ b/rplugin/python3/docstring.py
@@ -127,7 +127,7 @@ class Main(object):
         current_line_number = int(current_line_number) - 1
         current_line = self.nvim.current.line
 
-        if not current_line.startswith("def "):
+        if 'def' not in current_line:
             return
 
         method_string = ""


### PR DESCRIPTION
I fixed the bug that docstring.nvim does not work for methods
not in top-level (which means not indented).